### PR TITLE
Update link in the intro tutorial

### DIFF
--- a/tutorial/01-Introduction-to-Ibis.ipynb
+++ b/tutorial/01-Introduction-to-Ibis.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# Getting started\n",
     "\n",
-    "To start using Ibis, you need a Python environment with Ibis installed. If you're running through this tutorial on your own machine (rather than binder) please follow the [installation instructions for SQLite](https://ibis-project.org/docs/latest/backends/SQLite/) to setup an environment.\n",
+    "To start using Ibis, you need a Python environment with Ibis installed. If you're running through this tutorial on your own machine (rather than binder) please follow the [installation instructions](https://ibis-project.org/install/) to setup an environment.\n",
     "\n",
     "You'll also need access to the `geography.db` database hosted [here](https://storage.googleapis.com/ibis-tutorial-data/geography.db). Every notebook in the tutorial starts with the following code to download the database if it doesn't already exist."
    ]


### PR DESCRIPTION
Just noticed the existing link to the installation instructions in the first tutorial notebook is not valid so I am proposing this change.