### PR TITLE
A few dockerfile changes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10-slim
+FROM python:3.10
 
 ARG NB_USER=jovyan
 ARG NB_UID=1000

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 notebook
 jupyterlab == 3.4.8
 altair
-ibis-framework[sqlite,duckdb,clickhouse]@git+https://github.com/ibis-project/ibis.git
+ibis-framework[sqlite,duckdb,clickhouse]
 ibis-substrait


### PR DESCRIPTION
- Don't use `-slim` python base image. While rare, some systems will need compailer access to install some dependencies. This shouldn't affect binder startup performance, since the base image is likely to already be cached on the execution nodes.
- Use the latest ibis release, rather than the dev branch.

Fixes #17.