### PR TITLE
Add missing order_by statement in 04-More-Value-Expressions when filtering for top 3 most frequent continents

### DIFF
--- a/tutorial/04-More-Value-Expressions.ipynb
+++ b/tutorial/04-More-Value-Expressions.ipynb
@@ -1,6 +1,7 @@
 {
  "cells": [
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -9,6 +10,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -40,6 +42,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -80,6 +83,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -113,6 +117,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -141,6 +146,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -166,6 +172,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -184,6 +191,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -207,6 +215,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -219,7 +228,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "top_continents = countries.continent.value_counts().limit(3).continent\n",
+    "top_continents = (\n",
+    "    countries.continent.value_counts()\n",
+    "    .order_by(ibis.desc(\"continent_count\"))\n",
+    "    .limit(3)\n",
+    "    .continent\n",
+    ")\n",
     "top_continents_filter = countries.continent.isin(top_continents)\n",
     "expr = countries[top_continents_filter]\n",
     "\n",
@@ -227,6 +241,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -243,6 +258,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -250,6 +266,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -277,6 +294,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -294,6 +312,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -313,6 +332,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -330,6 +350,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -349,6 +370,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -366,6 +388,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -404,6 +427,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -432,6 +456,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -458,6 +483,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -483,6 +509,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [


### PR DESCRIPTION
I added an `order_by` statement when calculating the top 3 most frequent continents. Without it:

<img width="241" alt="image" src="https://github.com/ibis-project/ibis-examples/assets/23366411/80605438-e457-4f8a-a2b1-508dbc9f331c">


With this PR:
<img width="466" alt="image" src="https://github.com/ibis-project/ibis-examples/assets/23366411/d69832ab-0650-4995-958b-09588a2411db">
