### PR TITLE
Pin pandas < 2.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,6 @@ notebook
 jupyterlab == 3.4.8
 ipywidgets
 altair
+pandas < 2.1
 ibis-framework[sqlite,duckdb,clickhouse]
 ibis-substrait

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ ipywidgets
 altair
 pandas < 2.1
 ibis-framework[sqlite,duckdb,clickhouse]
-ibis-substrait
+ibis-substrait < 3.1


### PR DESCRIPTION
Pandas 2.1 moved some imports, which breaks things on the current ibis release. Pinning to < 2.1 for now until the next ibis release.